### PR TITLE
Fix bearerAuth security scheme

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -513,9 +513,8 @@ paths:
 components:
   securitySchemes:
     bearerAuth:
-      type: apiKey
-      in: header
-      name: Authorization
+      type: http
+      scheme: bearer
       x-bearer-format: bearer
       x-default: default
 


### PR DESCRIPTION
For API requiring a `Bearer` token, OpenAPI supports the `bearer` scheme: https://swagger.io/docs/specification/authentication/bearer-authentication/