### PR TITLE
Fix spec file

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -961,7 +961,6 @@ components:
           items:
             $ref: '#/components/schemas/ToolsPart'
         tool_choice:
-          type: object
           description: Controls which (if any) function is called by the model. By default uses `auto`, which lets the model pick between generating a message or calling a function.
           oneOf:
             - type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1055,7 +1055,7 @@ components:
           type: string
         tool_call_id:
           type: string
-        required: [role, content, tool_call_id]
+      required: [role, content, tool_call_id]
 
     # End Message Params
 
@@ -1154,7 +1154,7 @@ components:
         delta:
           title: ChatCompletionChoiceDelta
           type: object
-          requied: [role]
+          required: [role]
           properties:
             token_id:
               type: integer


### PR DESCRIPTION
This pull request fixes a few errors in the spec file:

1. There seem to be an issue with the definition of `tool_choice`, containing both a `type: object` and a `oneOf` field. Only the `oneOf` is necessary.
2. A `required` property is indented one level too much
3. A type: `requied` => `required`