### PR TITLE
fix: mark ChatCompletionChunk.choices.finish_reason as nullable

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1109,6 +1109,7 @@ components:
                 type: integer
               finish_reason:
                 $ref: '#/components/schemas/FinishReason'
+                nullable: true
               logprobs:
                 type: number
                 nullable: true


### PR DESCRIPTION
`finish_reason` comes in as nullable from the API. I believe it's only ever populated on the final Choice. 