### PR TITLE
Add Readme to GitHub Action

### DIFF
--- a/.github/workflows/upload-to-stainless.yml
+++ b/.github/workflows/upload-to-stainless.yml
@@ -16,8 +16,7 @@ jobs:
           stainless_api_key: ${{ secrets.STAINLESS_API_KEY }}
           input_path: 'openapi.yaml'
           output_path: 'openapi.documented.yaml'
-          project_name: 'togetherai'
-          guess_config: true
+          project_name: 'TogetherAI'
       # - uses: readmeio/rdme@v8
       #   with:
       #     rdme: openapi "openapi.documented.yaml" --key=${{ secrets.README_TOKEN }} --id=${{ secrets.README_DEFINITION_ID }}

--- a/.github/workflows/upload-to-stainless.yml
+++ b/.github/workflows/upload-to-stainless.yml
@@ -17,6 +17,6 @@ jobs:
           input_path: 'openapi.yaml'
           output_path: 'openapi.documented.yaml'
           project_name: 'TogetherAI'
-      # - uses: readmeio/rdme@v8
-      #   with:
-      #     rdme: openapi "openapi.documented.yaml" --key=${{ secrets.README_TOKEN }} --id=${{ secrets.README_DEFINITION_ID }}
+      - uses: readmeio/rdme@v8
+        with:
+          rdme: openapi "openapi.documented.yaml" --key=${{ secrets.README_TOKEN }} --id=${{ secrets.README_DEFINITION_ID }}


### PR DESCRIPTION
This PR updates the Stainless action with Readme's github action, which automatically uploads the Open API spec decorated with Stainless's SDK examples to the Readme API docs.

Here's how it looks in our test Readme site:

<img width="1190" alt="image" src="https://github.com/user-attachments/assets/606bacca-b865-4b4b-ae05-66f3a572e4cc">

Before merging, two new secrets need to be set in this repo:

- README_TOKEN
- README_DEFINITION_ID