### PR TITLE
feat: add dedicated endpoints to public spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -705,13 +705,52 @@ paths:
       tags: ["Endpoints"]
       summary: List endpoints
       operationId: listEndpoints
+      parameters:
+        - name: type
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - dedicated
+              - serverless
+          description: Filter endpoints by type
+          example: dedicated
       responses:
         "200":
           description: "200"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EndpointList"
+                type: object
+                required:
+                  - object
+                  - data
+                properties:
+                  object:
+                    type: string
+                    enum:
+                      - list
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Endpoint"
+                example:
+                  object: "list"
+                  data:
+                    - object: "endpoint"
+                      id: "endpoint-d23901de-ef8f-44bf-b3e7-de9c1ca8f2d7"
+                      name: "devuser/meta-llama/Llama-3-8b-chat-hf-a32b82a1"
+                      display_name: "My Llama3 70b endpoint"
+                      model: "meta-llama/Llama-3-8b-chat-hf"
+                      hardware: "1x_nvidia_a100_80gb_sxm"
+                      type: "dedicated"
+                      owner: "devuser"
+                      state: "PENDING"
+                      autoscaling:
+                        min_replicas: 1
+                        max_replicas: 3
+                      created_at: "2025-02-04T10:43:55.405Z"
         "403":
           description: "Unauthorized"
           content:
@@ -754,218 +793,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorData"
 
-  /endpoints/{id}:
-    get:
-      tags: ["Endpoints"]
-      summary: Get endpoint by ID
-      operationId: getEndpoint
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: "200"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Endpoint"
-        "403":
-          description: "Unauthorized"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorData"
-        "500":
-          description: "Internal error"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorData"
-    delete:
-      tags: ["Endpoints"]
-      summary: Delete endpoint
-      operationId: deleteEndpoint
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: "200"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Endpoint"
-        "403":
-          description: "Unauthorized"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorData"
-        "500":
-          description: "Internal error"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorData"
-    patch:
-      tags: ["Endpoints"]
-      summary: Update endpoint
-      operationId: updateEndpoint
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                min_replicas:
-                  type: integer
-                  format: int32
-                  example: 2
-                max_replicas:
-                  type: integer
-                  format: int32
-                  example: 2
-      responses:
-        "200":
-          description: "200"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Endpoint"
-        "403":
-          description: "Unauthorized"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorData"
-        "500":
-          description: "Internal error"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorData"
-
-  /endpoints/{id}/hardware:
-    get:
-      tags: ["Endpoints"]
-      summary: Get available hardware for an endpoint
-      operationId: getEndpointHardware
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: "200"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/HardwareResponse"
-        "403":
-          description: "Unauthorized"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorData"
-        "500":
-          description: "Internal error"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorData"
-
-  /endpoints/{id}/start:
-    post:
-      tags: ["Endpoints"]
-      summary: Start endpoint
-      operationId: startEndpoint
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - hardware_id
-                - autoscaling
-              properties:
-                hardware_id:
-                  type: string
-                  example: "1x_nvidia_h100_80gb_sxm"
-                autoscaling:
-                  $ref: "#/components/schemas/Autoscaling"
-      responses:
-        "200":
-          description: "200"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Endpoint"
-        "403":
-          description: "Unauthorized"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorData"
-        "500":
-          description: "Internal error"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorData"
-
-  /endpoints/{id}/stop:
-    post:
-      tags: ["Endpoints"]
-      summary: Stop endpoint
-      operationId: stopEndpoint
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: "200"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Endpoint"
-        "403":
-          description: "Unauthorized"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorData"
-        "500":
-          description: "Internal error"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorData"
-
   /endpoints/{endpointId}:
     get:
       tags: ["Endpoints"]
@@ -986,6 +813,98 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Endpoint"
+        "403":
+          description: "Unauthorized"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "404":
+          description: "Not Found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "500":
+          description: "Internal error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+    patch:
+      tags: ["Endpoints"]
+      summary: Update endpoint
+      operationId: updateEndpoint
+      parameters:
+        - name: endpointId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The ID of the endpoint to update
+          example: endpoint-d23901de-ef8f-44bf-b3e7-de9c1ca8f2d7
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                display_name:
+                  type: string
+                  description: A human-readable name for the endpoint
+                  example: My Llama3 70b endpoint
+                state:
+                  type: string
+                  description: The desired state of the endpoint
+                  enum:
+                    - STARTED
+                    - STOPPED
+                  example: STARTED
+                autoscaling:
+                  $ref: "#/components/schemas/Autoscaling"
+                  description: New autoscaling configuration for the endpoint
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Endpoint"
+        "403":
+          description: "Unauthorized"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "404":
+          description: "Not Found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "500":
+          description: "Internal error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+
+    delete:
+      tags: ["Endpoints"]
+      summary: Delete endpoint
+      operationId: deleteEndpoint
+      parameters:
+        - name: endpointId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The ID of the endpoint to delete
+          example: endpoint-d23901de-ef8f-44bf-b3e7-de9c1ca8f2d7
+      responses:
+        "204":
+          description: "No Content - Endpoint successfully deleted"
         "403":
           description: "Unauthorized"
           content:
@@ -2677,30 +2596,6 @@ components:
           examples:
             - 5.42
 
-    Deployment:
-      type: object
-      properties:
-        object:
-          type: string
-          enum:
-            - deployment
-        status:
-          type: string
-          enum:
-            - running
-            - pending
-            - queued
-            - deployed
-            - cancel_requested
-            - cancelled
-            - error
-        autoscaling:
-          $ref: "#/components/schemas/Autoscaling"
-        hardware:
-          $ref: "#/components/schemas/EndpointHardware"
-        pricing:
-          $ref: "#/components/schemas/EndpointPricing"
-
     Endpoint:
       type: object
       properties:
@@ -2742,6 +2637,7 @@ components:
           enum:
             - PENDING
             - STARTED
+            - STOPPING
             - STOPPED
             - ERROR
         autoscaling:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2575,6 +2575,9 @@ components:
     Autoscaling:
       type: object
       description: Configuration for automatic scaling of replicas based on demand.
+      required:
+        - min_replicas
+        - max_replicas
       properties:
         min_replicas:
           type: integer
@@ -2592,6 +2595,11 @@ components:
     HardwareSpec:
       type: object
       description: Detailed specifications of a hardware configuration
+      required:
+        - gpu_type
+        - gpu_link
+        - gpu_memory
+        - gpu_count
       properties:
         gpu_type:
           type: string
@@ -2619,6 +2627,8 @@ components:
     EndpointPricing:
       type: object
       description: Pricing details for using an endpoint
+      required:
+        - cents_per_minute
       properties:
         cents_per_minute:
           type: number
@@ -2630,6 +2640,8 @@ components:
     HardwareAvailability:
       type: object
       description: Indicates the current availability status of a hardware configuration
+      required:
+        - status
       properties:
         status:
           type: string
@@ -2642,6 +2654,12 @@ components:
     HardwareWithStatus:
       type: object
       description: Hardware configuration details including current availability status
+      required:
+        - object
+        - name
+        - pricing
+        - specs
+        - updated_at
       properties:
         object:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -933,8 +933,11 @@ paths:
   /hardware:
     get:
       tags: ["Hardware"]
-      summary: List available hardware configurations 
-      description: Returns a list of available hardware configurations for deploying models. When a model parameter is provided, it returns only hardware configurations compatible with that model, including their current availability status.
+      summary: List available hardware configurations
+      description: >
+        Returns a list of available hardware configurations for deploying models.
+        When a model parameter is provided, it returns only hardware configurations compatible 
+        with that model, including their current availability status.
       operationId: listHardware
       parameters:
         - name: model
@@ -942,7 +945,9 @@ paths:
           required: false
           schema:
             type: string
-          description: Filter hardware configurations by model compatibility
+          description: >
+            Filter hardware configurations by model compatibility. When provided, 
+            the response includes availability status for each compatible configuration.
           example: meta-llama/Llama-3-70b-chat-hf
       responses:
         "200":
@@ -950,59 +955,19 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - type: object
-                    description: Response when no model filter is provided
-                    required:
-                      - object
-                      - data
-                    properties:
-                      object:
-                        type: string
-                        enum:
-                          - list
-                      data:
-                        type: array
-                        items:
-                          allOf:
-                            - $ref: "#/components/schemas/HardwareWithStatus"
-                            - type: object
-                              properties:
-                                availability:
-                                  not: {}
-                  - type: object
-                    description: Response when model filter is provided
-                    required:
-                      - object
-                      - data
-                    properties:
-                      object:
-                        type: string
-                        enum:
-                          - list
-                      data:
-                        type: array
-                        items:
-                          allOf:
-                            - $ref: "#/components/schemas/HardwareWithStatus"
-                            - type: object
-                              required:
-                                - availability
-                example:
-                  object: "list"
+                type: object
+                required:
+                  - object
+                  - data
+                properties:
+                  object:
+                    type: string
+                    enum:
+                      - list
                   data:
-                    - object: "hardware"
-                      name: "2x_nvidia_a100_80gb_sxm"
-                      pricing:
-                        input: 0
-                        output: 0
-                        cents_per_minute: 5.42
-                      specs:
-                        gpu_type: "a100-80gb"
-                        gpu_link: "sxm"
-                        gpu_memory: 80
-                        gpu_count: 2
-                      updated_at: "2024-01-01T00:00:00Z"
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/HardwareWithStatus"
         "403":
           description: "Unauthorized"
           content:
@@ -1058,21 +1023,21 @@ components:
                 example: Our solar system orbits the Milky Way galaxy at about 515,000 mph
           example:
             - {
-              "title": "Llama",
-              "text": "The llama is a domesticated South American camelid, widely used as a meat and pack animal by Andean cultures since the pre-Columbian era.",
-            }
+                "title": "Llama",
+                "text": "The llama is a domesticated South American camelid, widely used as a meat and pack animal by Andean cultures since the pre-Columbian era.",
+              }
             - {
-              "title": "Panda",
-              "text": "The giant panda (Ailuropoda melanoleuca), also known as the panda bear or simply panda, is a bear species endemic to China.",
-            }
+                "title": "Panda",
+                "text": "The giant panda (Ailuropoda melanoleuca), also known as the panda bear or simply panda, is a bear species endemic to China.",
+              }
             - {
-              "title": "Guanaco",
-              "text": "The guanaco is a camelid native to South America, closely related to the llama. Guanacos are one of two wild South American camelids; the other species is the vicuña, which lives at higher elevations.",
-            }
+                "title": "Guanaco",
+                "text": "The guanaco is a camelid native to South America, closely related to the llama. Guanacos are one of two wild South American camelids; the other species is the vicuña, which lives at higher elevations.",
+              }
             - {
-              "title": "Wild Bactrian camel",
-              "text": "The wild Bactrian camel (Camelus ferus) is an endangered species of camel endemic to Northwest China and southwestern Mongolia.",
-            }
+                "title": "Wild Bactrian camel",
+                "text": "The wild Bactrian camel (Camelus ferus) is an endangered species of camel endemic to Northwest China and southwestern Mongolia.",
+              }
         top_n:
           type: integer
           description: The number of top results to return.
@@ -1132,21 +1097,21 @@ components:
                     nullable: true
           example:
             - {
-              "index": 0,
-              "relevance_score": 0.29980177813003117,
-              "document":
-                {
-                  "text": '{"title":"Llama","text":"The llama is a domesticated South American camelid, widely used as a meat and pack animal by Andean cultures since the pre-Columbian era."}',
-                },
-            }
+                "index": 0,
+                "relevance_score": 0.29980177813003117,
+                "document":
+                  {
+                    "text": '{"title":"Llama","text":"The llama is a domesticated South American camelid, widely used as a meat and pack animal by Andean cultures since the pre-Columbian era."}',
+                  },
+              }
             - {
-              "index": 2,
-              "relevance_score": 0.2752447527354349,
-              "document":
-                {
-                  "text": '{"title":"Guanaco","text":"The guanaco is a camelid native to South America, closely related to the llama. Guanacos are one of two wild South American camelids; the other species is the vicuña, which lives at higher elevations."}',
-                },
-            }
+                "index": 2,
+                "relevance_score": 0.2752447527354349,
+                "document":
+                  {
+                    "text": '{"title":"Guanaco","text":"The guanaco is a camelid native to South America, closely related to the llama. Guanacos are one of two wild South American camelids; the other species is the vicuña, which lives at higher elevations."}',
+                  },
+              }
         usage:
           $ref: "#/components/schemas/UsageData"
           example:
@@ -1345,7 +1310,7 @@ components:
 
             format: float
           description: Adjusts the likelihood of specific tokens appearing in the generated output.
-          example: {"1024": -10.5, "105": 21.4}
+          example: { "1024": -10.5, "105": 21.4 }
         seed:
           type: integer
           description: Seed value for reproducibility.
@@ -1593,7 +1558,7 @@ components:
           format: int32
         context_length_exceeded_behavior:
           type: string
-          enum: [ "truncate", "error" ]
+          enum: ["truncate", "error"]
           default: "error"
           description: Defined the behavior of the API when max_tokens exceed the maximum context length of the model. When set to 'error', API will return 400 with appropriate error message. When set to 'truncate', override the max_tokens with maximum context length of the model.
         repetition_penalty:
@@ -1633,7 +1598,7 @@ components:
             type: number
             format: float
           description: Adjusts the likelihood of specific tokens appearing in the generated output.
-          example: {"1024": -10.5, "105": 21.4}
+          example: { "1024": -10.5, "105": 21.4 }
         seed:
           type: integer
           description: Seed value for reproducibility.
@@ -2646,10 +2611,10 @@ components:
 
     HardwareWithStatus:
       type: object
-      description: Hardware configuration details including current availability status
+      description: Hardware configuration details with optional availability status
       required:
         - object
-        - name
+        - id
         - pricing
         - specs
         - updated_at
@@ -2658,7 +2623,7 @@ components:
           type: string
           enum:
             - hardware
-        name:
+        id:
           type: string
           description: Unique identifier for the hardware configuration
           examples:
@@ -2714,7 +2679,7 @@ components:
             - STARTED
             - STOPPED
           default: STARTED
-          example: STARTED        
+          example: STARTED
 
     DedicatedEndpoint:
       type: object
@@ -2773,7 +2738,7 @@ components:
           enum:
             - PENDING
             - STARTING
-            - STARTED 
+            - STARTED
             - STOPPING
             - STOPPED
             - ERROR
@@ -2835,7 +2800,7 @@ components:
           enum:
             - PENDING
             - STARTING
-            - STARTED 
+            - STARTED
             - STOPPING
             - STOPPED
             - ERROR

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2483,45 +2483,12 @@ components:
         created_at:
           type: string
         level:
-          type: string
-          enum:
-            - null
-            - info
-            - warning
-            - error
-            - legacy_info
-            - legacy_iwarning
-            - legacy_ierror
+          anyOf:
+            - $ref: "#/components/schemas/FinetuneEventLevels"
         message:
           type: string
         type:
-          type: string
-          enum:
-            - job_pending
-            - job_start
-            - job_stopped
-            - model_downloading
-            - model_download_complete
-            - training_data_downloading
-            - training_data_download_complete
-            - validation_data_downloading
-            - validation_data_download_complete
-            - wandb_init
-            - training_start
-            - checkpoint_save
-            - billing_limit
-            - epoch_complete
-            - training_complete
-            - model_compressing
-            - model_compression_complete
-            - model_uploading
-            - model_upload_complete
-            - job_complete
-            - job_error
-            - cancel_requested
-            - job_restarted
-            - refund
-            - warning
+          $ref: "#/components/schemas/FinetuneEventType"
         param_count:
           type: integer
         token_count:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2672,22 +2672,55 @@ components:
         id:
           type: string
           examples:
-            - endpoint-4c88c864-9f71-4c50-9b32-879001a46511
+            - endpoint-d23901de-ef8f-44bf-b3e7-de9c1ca8f2d7
         name:
           type: string
           examples:
-            - devuser/meta-llama/Llama-3-70b-chat-hf-prodDeploy7
+            - devuser/meta-llama/Llama-3-8b-chat-hf-a32b82a1
+        display_name:
+          type: string
+          description: A human-readable name for the endpoint
+          examples:
+            - My Llama3 70b endpoint
         model:
-          $ref: "#/components/schemas/NamedObject"
+          type: string
+          examples:
+            - meta-llama/Llama-3-8b-chat-hf
+        hardware:
+          type: string
+          examples:
+            - 1x_nvidia_a100_80gb_sxm
+        type:
+          type: string
+          enum:
+            - dedicated
         owner:
-          $ref: "#/components/schemas/Owner"
-        deployments:
-          type: array
-          items:
-            $ref: "#/components/schemas/Deployment"
+          type: string
+          examples:
+            - devuser
+        state:
+          type: string
+          enum:
+            - PENDING
+            - RUNNING
+            - STOPPED
+            - ERROR
+        autoscaling:
+          $ref: "#/components/schemas/Autoscaling"
         created_at:
           type: string
           format: date-time
+      required:
+        - object
+        - id
+        - name
+        - model
+        - hardware
+        - type
+        - owner
+        - state
+        - autoscaling
+        - created_at
 
     EndpointList:
       type: object
@@ -2746,19 +2779,29 @@ components:
 
     CreateEndpointRequest:
       type: object
+      required:
+        - model
+        - hardware
+        - autoscaling
       properties:
+        display_name:
+          type: string
+          description: A human-readable name for the endpoint
+          examples:
+            - My Llama3 70b endpoint
         model:
           type: string
+          description: The model to deploy on this endpoint
           examples:
-            - meta-llama/Llama-3-70b-chat-hf
-        suffix:
+            - meta-llama/Llama-3-8b-chat-hf
+        hardware:
           type: string
+          description: The hardware configuration to use for this endpoint
           examples:
-            - prodDeploy7
-        hardware_name:
-          type: string
-          examples:
-            - 2x_nvidia_a100_80gb_sxm
+            - 1x_nvidia_a100_80gb_sxm
+        autoscaling:
+          $ref: "#/components/schemas/Autoscaling"
+          description: Configuration for automatic scaling of the endpoint
 
     StartEndpointRequest:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1187,8 +1187,6 @@ components:
           required:
             - type
             - message
-            - param
-            - code
 
     FinishReason:
       type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2653,18 +2653,6 @@ components:
       type: object
       description: Pricing details for using an endpoint
       properties:
-        input:
-          type: number
-          format: float
-          description: Cost per 1000 input tokens
-          examples:
-            - 0
-        output:
-          type: number
-          format: float
-          description: Cost per 1000 output tokens
-          examples:
-            - 0
         cents_per_minute:
           type: number
           format: float

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -741,23 +741,17 @@ paths:
                   data:
                     type: array
                     items:
-                      $ref: "#/components/schemas/Endpoint"
+                      $ref: "#/components/schemas/ListEndpoint"
                 example:
                   object: "list"
                   data:
                     - object: "endpoint"
-                      id: "endpoint-d23901de-ef8f-44bf-b3e7-de9c1ca8f2d7"
-                      name: "devuser/meta-llama/Llama-3-8b-chat-hf-a32b82a1"
-                      display_name: "My Llama3 70b endpoint"
-                      model: "meta-llama/Llama-3-8b-chat-hf"
-                      hardware: "1x_nvidia_a100_80gb_sxm"
-                      type: "dedicated"
-                      owner: "devuser"
-                      state: "PENDING"
-                      autoscaling:
-                        min_replicas: 1
-                        max_replicas: 3
-                      created_at: "2025-02-04T10:43:55.405Z"
+                      name: "allenai/OLMo-7B"
+                      model: "allenai/OLMo-7B"
+                      type: "serverless"
+                      owner: "together"
+                      state: "STARTED"
+                      created_at: "2024-02-28T21:34:35.444Z"
         "403":
           description: "Unauthorized"
           content:
@@ -787,7 +781,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Endpoint"
+                $ref: "#/components/schemas/DedicatedEndpoint"
         "403":
           description: "Unauthorized"
           content:
@@ -821,7 +815,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Endpoint"
+                $ref: "#/components/schemas/DedicatedEndpoint"
         "403":
           description: "Unauthorized"
           content:
@@ -881,7 +875,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Endpoint"
+                $ref: "#/components/schemas/DedicatedEndpoint"
         "403":
           description: "Unauthorized"
           content:
@@ -2722,7 +2716,7 @@ components:
           default: STARTED
           example: STARTED        
 
-    Endpoint:
+    DedicatedEndpoint:
       type: object
       description: Details about a dedicated endpoint deployment
       required:
@@ -2768,7 +2762,6 @@ components:
           type: string
           enum:
             - dedicated
-            - serverless
           description: The type of endpoint
           example: dedicated
         owner:
@@ -2779,6 +2772,7 @@ components:
           type: string
           enum:
             - PENDING
+            - STARTING
             - STARTED 
             - STOPPING
             - STOPPED
@@ -2793,3 +2787,62 @@ components:
           format: date-time
           description: Timestamp when the endpoint was created
           example: 2025-02-04T10:43:55.405Z
+
+    ListEndpoint:
+      type: object
+      description: Details about an endpoint when listed via the list endpoint
+      required:
+        - id
+        - object
+        - name
+        - model
+        - type
+        - owner
+        - state
+        - created_at
+      properties:
+        object:
+          type: string
+          enum:
+            - endpoint
+          description: The type of object
+          example: endpoint
+        id:
+          type: string
+          description: Unique identifier for the endpoint
+          example: endpoint-d23901de-ef8f-44bf-b3e7-de9c1ca8f2d7
+        name:
+          type: string
+          description: System name for the endpoint
+          example: allenai/OLMo-7B
+        model:
+          type: string
+          description: The model deployed on this endpoint
+          example: allenai/OLMo-7B
+        type:
+          type: string
+          enum:
+            - serverless
+            - dedicated
+          description: The type of endpoint
+          example: serverless
+        owner:
+          type: string
+          description: The owner of this endpoint
+          example: together
+        state:
+          type: string
+          enum:
+            - PENDING
+            - STARTING
+            - STARTED 
+            - STOPPING
+            - STOPPED
+            - ERROR
+          description: Current state of the endpoint
+          example: STARTED
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp when the endpoint was created
+          example: 2024-02-28T21:34:35.444Z

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -840,6 +840,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorData"
+
     patch:
       tags: ["Endpoints"]
       summary: Update endpoint, this can also be used to start or stop a dedicated endpoint
@@ -2706,6 +2707,22 @@ components:
         autoscaling:
           $ref: "#/components/schemas/Autoscaling"
           description: Configuration for automatic scaling of the endpoint
+        disable_prompt_cache:
+          type: boolean
+          description: Whether to disable the prompt cache for this endpoint
+          default: false
+        disable_speculative_decoding:
+          type: boolean
+          description: Whether to disable speculative decoding for this endpoint
+          default: false
+        state:
+          type: string
+          description: The desired state of the endpoint
+          enum:
+            - STARTED
+            - STOPPED
+          default: STARTED
+          example: STARTED        
 
     Endpoint:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2706,3 +2706,75 @@ components:
         autoscaling:
           $ref: "#/components/schemas/Autoscaling"
           description: Configuration for automatic scaling of the endpoint
+
+    Endpoint:
+      type: object
+      description: Details about a dedicated endpoint deployment
+      required:
+        - object
+        - id
+        - name
+        - display_name
+        - model
+        - hardware
+        - type
+        - owner
+        - state
+        - autoscaling
+        - created_at
+      properties:
+        object:
+          type: string
+          enum:
+            - endpoint
+          description: The type of object
+          example: endpoint
+        id:
+          type: string
+          description: Unique identifier for the endpoint
+          example: endpoint-d23901de-ef8f-44bf-b3e7-de9c1ca8f2d7
+        name:
+          type: string
+          description: System name for the endpoint
+          example: devuser/meta-llama/Llama-3-8b-chat-hf-a32b82a1
+        display_name:
+          type: string
+          description: Human-readable name for the endpoint
+          example: My Llama3 70b endpoint
+        model:
+          type: string
+          description: The model deployed on this endpoint
+          example: meta-llama/Llama-3-8b-chat-hf
+        hardware:
+          type: string
+          description: The hardware configuration used for this endpoint
+          example: 1x_nvidia_a100_80gb_sxm
+        type:
+          type: string
+          enum:
+            - dedicated
+            - serverless
+          description: The type of endpoint
+          example: dedicated
+        owner:
+          type: string
+          description: The owner of this endpoint
+          example: devuser
+        state:
+          type: string
+          enum:
+            - PENDING
+            - STARTED 
+            - STOPPING
+            - STOPPED
+            - ERROR
+          description: Current state of the endpoint
+          example: STARTED
+        autoscaling:
+          $ref: "#/components/schemas/Autoscaling"
+          description: Configuration for automatic scaling of the endpoint
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp when the endpoint was created
+          example: 2025-02-04T10:43:55.405Z

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -700,6 +700,219 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorData"
+  /endpoints:
+    get:
+      tags: ["Endpoints"]
+      summary: List endpoints
+      operationId: listEndpoints
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EndpointList"
+        "403":
+          description: "Unauthorized"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "500":
+          description: "Internal error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+    post:
+      tags: ["Endpoints"]
+      summary: Create endpoint
+      operationId: createEndpoint
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateEndpointRequest"
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Endpoint"
+        "403":
+          description: "Unauthorized"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "500":
+          description: "Internal error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+
+  /endpoints/{id}:
+    get:
+      tags: ["Endpoints"]
+      summary: Get endpoint by ID
+      operationId: getEndpoint
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Endpoint"
+        "403":
+          description: "Unauthorized"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "500":
+          description: "Internal error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+    delete:
+      tags: ["Endpoints"]
+      summary: Delete endpoint
+      operationId: deleteEndpoint
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Endpoint"
+        "403":
+          description: "Unauthorized"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "500":
+          description: "Internal error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+
+  /endpoints/{id}/hardware:
+    get:
+      tags: ["Endpoints"]
+      summary: Get available hardware for an endpoint
+      operationId: getEndpointHardware
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HardwareResponse"
+        "403":
+          description: "Unauthorized"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "500":
+          description: "Internal error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+
+  /endpoints/{id}/start:
+    post:
+      tags: ["Endpoints"]
+      summary: Start endpoint
+      operationId: startEndpoint
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StartEndpointRequest"
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Endpoint"
+        "403":
+          description: "Unauthorized"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "500":
+          description: "Internal error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+
+  /endpoints/{id}/stop:
+    post:
+      tags: ["Endpoints"]
+      summary: Stop endpoint
+      operationId: stopEndpoint
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Endpoint"
+        "403":
+          description: "Unauthorized"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "500":
+          description: "Internal error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+
 components:
   securitySchemes:
     bearerAuth:
@@ -1668,7 +1881,6 @@ components:
           type: string
         logprob:
           type: number
-          format: float
         special:
           type: boolean
 
@@ -2303,3 +2515,224 @@ components:
           format: float
           default: 0.0
           description: The ratio of the final learning rate to the peak learning rate
+
+    NamedObject:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - model
+        id:
+          type: string
+          examples:
+            - model-42168e53-cfc5-474e-adb1-06fcd7aba56b
+        name:
+          type: string
+          examples:
+            - meta-llama/Llama-3-70b-chat-hf
+
+    Owner:
+      type: object
+      properties:
+        user:
+          type: string
+          examples:
+            - devuser
+        organization:
+          type: string
+          examples:
+            - together.ai
+
+    Autoscaling:
+      type: object
+      properties:
+        min_replicas:
+          type: integer
+          format: int32
+          examples:
+            - 2
+        max_replicas:
+          type: integer
+          format: int32
+          examples:
+            - 5
+
+    HardwareSpec:
+      type: object
+      properties:
+        gpu_type:
+          type: string
+          examples:
+            - a100-80gb
+        gpu_link:
+          type: string
+          examples:
+            - sxm
+        gpu_memory:
+          type: number
+          format: float
+          examples:
+            - 80
+        gpu_count:
+          type: integer
+          format: int32
+          examples:
+            - 2
+
+    EndpointHardware:
+      type: object
+      properties:
+        name:
+          type: string
+          examples:
+            - 2x_nvidia_a100_80gb_sxm
+        specs:
+          $ref: "#/components/schemas/HardwareSpec"
+
+    EndpointPricing:
+      type: object
+      properties:
+        input:
+          type: number
+          format: float
+          examples:
+            - 0
+        output:
+          type: number
+          format: float
+          examples:
+            - 0
+        cents_per_minute:
+          type: number
+          format: float
+          examples:
+            - 5.42
+
+    Deployment:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - deployment
+        status:
+          type: string
+          enum:
+            - running
+            - pending
+            - queued
+            - deployed
+            - cancel_requested
+            - cancelled
+            - error
+        autoscaling:
+          $ref: "#/components/schemas/Autoscaling"
+        hardware:
+          $ref: "#/components/schemas/EndpointHardware"
+        pricing:
+          $ref: "#/components/schemas/EndpointPricing"
+
+    Endpoint:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - endpoint
+        id:
+          type: string
+          examples:
+            - endpoint-4c88c864-9f71-4c50-9b32-879001a46511
+        name:
+          type: string
+          examples:
+            - devuser/meta-llama/Llama-3-70b-chat-hf-prodDeploy7
+        model:
+          $ref: "#/components/schemas/NamedObject"
+        owner:
+          $ref: "#/components/schemas/Owner"
+        deployments:
+          type: array
+          items:
+            $ref: "#/components/schemas/Deployment"
+        created_at:
+          type: string
+          format: date-time
+
+    EndpointList:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - list
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Endpoint"
+
+    HardwareAvailability:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            - available
+            - unavailable
+            - insufficient
+
+    HardwareWithStatus:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - hardware
+        name:
+          type: string
+          examples:
+            - 2x_nvidia_a100_80gb_sxm
+        pricing:
+          $ref: "#/components/schemas/EndpointPricing"
+        specs:
+          $ref: "#/components/schemas/HardwareSpec"
+        availability:
+          $ref: "#/components/schemas/HardwareAvailability"
+        updated_at:
+          type: string
+          format: date-time
+
+    HardwareResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - list
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/HardwareWithStatus"
+
+    CreateEndpointRequest:
+      type: object
+      properties:
+        model:
+          type: string
+          examples:
+            - meta-llama/Llama-3-70b-chat-hf
+        suffix:
+          type: string
+          examples:
+            - prodDeploy7
+        hardware_name:
+          type: string
+          examples:
+            - 2x_nvidia_a100_80gb_sxm
+
+    StartEndpointRequest:
+      type: object
+      properties:
+        autoscaling:
+          $ref: "#/components/schemas/Autoscaling"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -813,6 +813,50 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorData"
+    patch:
+      tags: ["Endpoints"]
+      summary: Update endpoint
+      operationId: updateEndpoint
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                min_replicas:
+                  type: integer
+                  format: int32
+                  example: 2
+                max_replicas:
+                  type: integer
+                  format: int32
+                  example: 2
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Endpoint"
+        "403":
+          description: "Unauthorized"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "500":
+          description: "Internal error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
 
   /endpoints/{id}/hardware:
     get:
@@ -861,7 +905,16 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/StartEndpointRequest"
+              type: object
+              required:
+                - hardware_id
+                - autoscaling
+              properties:
+                hardware_id:
+                  type: string
+                  example: "1x_nvidia_h100_80gb_sxm"
+                autoscaling:
+                  $ref: "#/components/schemas/Autoscaling"
       responses:
         "200":
           description: "200"
@@ -2709,6 +2762,12 @@ components:
 
     StartEndpointRequest:
       type: object
+      required:
+        - hardware_id
+        - autoscaling
       properties:
+        hardware_id:
+          type: string
+          example: "1x_nvidia_h100_80gb_sxm"
         autoscaling:
           $ref: "#/components/schemas/Autoscaling"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -703,7 +703,7 @@ paths:
   /endpoints:
     get:
       tags: ["Endpoints"]
-      summary: List endpoints
+      summary: List all endpoints, can be filtered by type
       operationId: listEndpoints
       parameters:
         - name: type
@@ -765,7 +765,7 @@ paths:
                 $ref: "#/components/schemas/ErrorData"
     post:
       tags: ["Endpoints"]
-      summary: Create endpoint
+      summary: Create a dedicated endpoint, it will start automatically
       operationId: createEndpoint
       requestBody:
         required: true
@@ -833,7 +833,7 @@ paths:
                 $ref: "#/components/schemas/ErrorData"
     patch:
       tags: ["Endpoints"]
-      summary: Update endpoint
+      summary: Update endpoint, this can also be used to start or stop a dedicated endpoint
       operationId: updateEndpoint
       parameters:
         - name: endpointId
@@ -913,6 +913,91 @@ paths:
                 $ref: "#/components/schemas/ErrorData"
         "404":
           description: "Not Found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "500":
+          description: "Internal error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+
+  /hardware:
+    get:
+      tags: ["Hardware"]
+      summary: List available hardware configurations
+      operationId: listHardware
+      parameters:
+        - name: model
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter hardware configurations by model compatibility
+          example: meta-llama/Llama-3-70b-chat-hf
+      responses:
+        "200":
+          description: "List of available hardware configurations"
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    description: Response when no model filter is provided
+                    required:
+                      - object
+                      - data
+                    properties:
+                      object:
+                        type: string
+                        enum:
+                          - list
+                      data:
+                        type: array
+                        items:
+                          allOf:
+                            - $ref: "#/components/schemas/HardwareWithStatus"
+                            - type: object
+                              properties:
+                                availability:
+                                  not: {}
+                  - type: object
+                    description: Response when model filter is provided
+                    required:
+                      - object
+                      - data
+                    properties:
+                      object:
+                        type: string
+                        enum:
+                          - list
+                      data:
+                        type: array
+                        items:
+                          allOf:
+                            - $ref: "#/components/schemas/HardwareWithStatus"
+                            - type: object
+                              required:
+                                - availability
+                example:
+                  object: "list"
+                  data:
+                    - object: "hardware"
+                      name: "2x_nvidia_a100_80gb_sxm"
+                      pricing:
+                        input: 0
+                        output: 0
+                        cents_per_minute: 5.42
+                      specs:
+                        gpu_type: "a100-80gb"
+                        gpu_link: "sxm"
+                        gpu_memory: 80
+                        gpu_count: 2
+                      updated_at: "2024-01-01T00:00:00Z"
+        "403":
+          description: "Unauthorized"
           content:
             application/json:
               schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -966,6 +966,45 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorData"
 
+  /endpoints/{endpointId}:
+    get:
+      tags: ["Endpoints"]
+      summary: Get endpoint by ID
+      operationId: getEndpoint
+      parameters:
+        - name: endpointId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The ID of the endpoint to retrieve
+          example: endpoint-d23901de-ef8f-44bf-b3e7-de9c1ca8f2d7
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Endpoint"
+        "403":
+          description: "Unauthorized"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "404":
+          description: "Not Found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+        "500":
+          description: "Internal error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorData"
+
 components:
   securitySchemes:
     bearerAuth:
@@ -2702,7 +2741,7 @@ components:
           type: string
           enum:
             - PENDING
-            - RUNNING
+            - STARTED
             - STOPPED
             - ERROR
         autoscaling:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2261,7 +2261,7 @@ components:
         events:
           type: array
           items:
-            $ref: "#/components/schemas/FinetuneEvent"
+            $ref: "#/components/schemas/FineTuneEvent"
         token_count:
           type: integer
         param_count:
@@ -2290,30 +2290,6 @@ components:
         - error
         - completed
 
-    FinetuneEvent:
-      type: object
-      properties:
-        object:
-          type: string
-          enum:
-            - "FinetuneEvent"
-        created_at:
-          type: string
-        level:
-          anyOf:
-            - $ref: "#/components/schemas/FinetuneEventLevels"
-        message:
-          type: string
-        type:
-          $ref: "#/components/schemas/FinetuneEventType"
-        param_count:
-          type: integer
-        token_count:
-          type: integer
-        wandb_url:
-          type: string
-        hash:
-          type: string
     FinetuneEventLevels:
       type: string
       enum:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -704,6 +704,7 @@ paths:
     get:
       tags: ["Endpoints"]
       summary: List all endpoints, can be filtered by type
+      description: Returns a list of all endpoints associated with your account. You can filter the results by type (dedicated or serverless).
       operationId: listEndpoints
       parameters:
         - name: type
@@ -766,6 +767,7 @@ paths:
     post:
       tags: ["Endpoints"]
       summary: Create a dedicated endpoint, it will start automatically
+      description: Creates a new dedicated endpoint for serving models. The endpoint will automatically start after creation. You can deploy any supported model on hardware configurations that meet the model's requirements.
       operationId: createEndpoint
       requestBody:
         required: true
@@ -797,6 +799,7 @@ paths:
     get:
       tags: ["Endpoints"]
       summary: Get endpoint by ID
+      description: Retrieves details about a specific endpoint, including its current state, configuration, and scaling settings.
       operationId: getEndpoint
       parameters:
         - name: endpointId
@@ -834,6 +837,7 @@ paths:
     patch:
       tags: ["Endpoints"]
       summary: Update endpoint, this can also be used to start or stop a dedicated endpoint
+      description: Updates an existing endpoint's configuration. You can modify the display name, autoscaling settings, or change the endpoint's state (start/stop).
       operationId: updateEndpoint
       parameters:
         - name: endpointId
@@ -893,6 +897,7 @@ paths:
     delete:
       tags: ["Endpoints"]
       summary: Delete endpoint
+      description: Permanently deletes an endpoint. This action cannot be undone.
       operationId: deleteEndpoint
       parameters:
         - name: endpointId
@@ -927,7 +932,8 @@ paths:
   /hardware:
     get:
       tags: ["Hardware"]
-      summary: List available hardware configurations
+      summary: List available hardware configurations 
+      description: Returns a list of available hardware configurations for deploying models. When a model parameter is provided, it returns only hardware configurations compatible with that model, including their current availability status.
       operationId: listHardware
       parameters:
         - name: model
@@ -2588,177 +2594,80 @@ components:
           default: 0.0
           description: The ratio of the final learning rate to the peak learning rate
 
-    NamedObject:
-      type: object
-      properties:
-        object:
-          type: string
-          enum:
-            - model
-        id:
-          type: string
-          examples:
-            - model-42168e53-cfc5-474e-adb1-06fcd7aba56b
-        name:
-          type: string
-          examples:
-            - meta-llama/Llama-3-70b-chat-hf
-
-    Owner:
-      type: object
-      properties:
-        user:
-          type: string
-          examples:
-            - devuser
-        organization:
-          type: string
-          examples:
-            - together.ai
-
     Autoscaling:
       type: object
+      description: Configuration for automatic scaling of replicas based on demand.
       properties:
         min_replicas:
           type: integer
           format: int32
+          description: The minimum number of replicas to maintain, even when there is no load
           examples:
             - 2
         max_replicas:
           type: integer
           format: int32
+          description: The maximum number of replicas to scale up to under load
           examples:
             - 5
 
     HardwareSpec:
       type: object
+      description: Detailed specifications of a hardware configuration
       properties:
         gpu_type:
           type: string
+          description: The type/model of GPU
           examples:
             - a100-80gb
         gpu_link:
           type: string
+          description: The GPU interconnect technology
           examples:
             - sxm
         gpu_memory:
           type: number
           format: float
+          description: Amount of GPU memory in GB
           examples:
             - 80
         gpu_count:
           type: integer
           format: int32
+          description: Number of GPUs in this configuration
           examples:
             - 2
 
-    EndpointHardware:
-      type: object
-      properties:
-        name:
-          type: string
-          examples:
-            - 2x_nvidia_a100_80gb_sxm
-        specs:
-          $ref: "#/components/schemas/HardwareSpec"
-
     EndpointPricing:
       type: object
+      description: Pricing details for using an endpoint
       properties:
         input:
           type: number
           format: float
+          description: Cost per 1000 input tokens
           examples:
             - 0
         output:
           type: number
           format: float
+          description: Cost per 1000 output tokens
           examples:
             - 0
         cents_per_minute:
           type: number
           format: float
+          description: Cost per minute of endpoint uptime in cents
           examples:
             - 5.42
 
-    Endpoint:
-      type: object
-      properties:
-        object:
-          type: string
-          enum:
-            - endpoint
-        id:
-          type: string
-          examples:
-            - endpoint-d23901de-ef8f-44bf-b3e7-de9c1ca8f2d7
-        name:
-          type: string
-          examples:
-            - devuser/meta-llama/Llama-3-8b-chat-hf-a32b82a1
-        display_name:
-          type: string
-          description: A human-readable name for the endpoint
-          examples:
-            - My Llama3 70b endpoint
-        model:
-          type: string
-          examples:
-            - meta-llama/Llama-3-8b-chat-hf
-        hardware:
-          type: string
-          examples:
-            - 1x_nvidia_a100_80gb_sxm
-        type:
-          type: string
-          enum:
-            - dedicated
-        owner:
-          type: string
-          examples:
-            - devuser
-        state:
-          type: string
-          enum:
-            - PENDING
-            - STARTED
-            - STOPPING
-            - STOPPED
-            - ERROR
-        autoscaling:
-          $ref: "#/components/schemas/Autoscaling"
-        created_at:
-          type: string
-          format: date-time
-      required:
-        - object
-        - id
-        - name
-        - model
-        - hardware
-        - type
-        - owner
-        - state
-        - autoscaling
-        - created_at
-
-    EndpointList:
-      type: object
-      properties:
-        object:
-          type: string
-          enum:
-            - list
-        data:
-          type: array
-          items:
-            $ref: "#/components/schemas/Endpoint"
-
     HardwareAvailability:
       type: object
+      description: Indicates the current availability status of a hardware configuration
       properties:
         status:
           type: string
+          description: The availability status of the hardware configuration
           enum:
             - available
             - unavailable
@@ -2766,6 +2675,7 @@ components:
 
     HardwareWithStatus:
       type: object
+      description: Hardware configuration details including current availability status
       properties:
         object:
           type: string
@@ -2773,6 +2683,7 @@ components:
             - hardware
         name:
           type: string
+          description: Unique identifier for the hardware configuration
           examples:
             - 2x_nvidia_a100_80gb_sxm
         pricing:
@@ -2784,18 +2695,7 @@ components:
         updated_at:
           type: string
           format: date-time
-
-    HardwareResponse:
-      type: object
-      properties:
-        object:
-          type: string
-          enum:
-            - list
-        data:
-          type: array
-          items:
-            $ref: "#/components/schemas/HardwareWithStatus"
+          description: Timestamp of when the hardware status was last updated
 
     CreateEndpointRequest:
       type: object
@@ -2822,15 +2722,3 @@ components:
         autoscaling:
           $ref: "#/components/schemas/Autoscaling"
           description: Configuration for automatic scaling of the endpoint
-
-    StartEndpointRequest:
-      type: object
-      required:
-        - hardware_id
-        - autoscaling
-      properties:
-        hardware_id:
-          type: string
-          example: "1x_nvidia_h100_80gb_sxm"
-        autoscaling:
-          $ref: "#/components/schemas/Autoscaling"


### PR DESCRIPTION
Adds dedicated endpoints to our public OpenAPI spec. Also fixes some small issues:

- Deduplicate `FinetuneEvent` and `FineTuneEvent`
- Mark 2 fields in error optional (as they are sometimes not given)

Fixes https://linear.app/together-ai/issue/ENG-20585/create-open-api-spec-for-de-docs