### PR TITLE
Move train_on_inputs to SFTType

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -713,6 +713,7 @@ paths:
                   type: boolean
                   default: auto
                   description: Whether to mask the user messages in conversational data or prompts in instruction data.
+                  deprecated: true
                 training_method:
                   type: object
                   oneOf:
@@ -2865,15 +2866,25 @@ components:
         - type
         - lora_r
         - lora_alpha
+
     TrainingMethodSFT:
       type: object
       properties:
         method:
           type: string
           enum: ["sft"]
+        train_on_inputs:
+          oneOf:
+            - type: boolean
+            - type: string
+              enum:
+                - auto
+          type: boolean
+          default: auto
+          description: Whether to mask the user messages in conversational data or prompts in instruction data.
       required:
         - method
-
+        - train_on_inputs
     TrainingMethodDPO:
       type: object
       properties:


### PR DESCRIPTION
Move train_on_inputs to SFTType struct instead of at the root ft level. 
We still support the old location but deprecate it.