### PR TITLE
Add stainless resource name to avoid conflict

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3391,6 +3391,7 @@ paths:
       summary: Create a new evaluation job
       description: Creates a new evaluation job for classify, score, or compare tasks
       operationId: evaluation-create
+      x-stainless-resource-name: evaluationCreate
       x-codeSamples:
         - lang: Python
           label: Together AI SDK (Python)
@@ -3533,10 +3534,10 @@ paths:
 
   /evaluations:
     get:
-      tags: ['Evaluations']
       summary: List evaluation jobs
       description: Get a list of evaluation jobs with optional filtering
       operationId: evaluations-list
+      x-stainless-resource-name: evaluationList
       parameters:
         - name: status
           in: query
@@ -5590,7 +5591,7 @@ components:
           type: string
         deleted:
           type: boolean
-    
+
     MultipartInitiateRequest:
       type: object
       required:
@@ -5619,7 +5620,7 @@ components:
           $ref: '#/components/schemas/FilePurpose'
         file_type:
           $ref: '#/components/schemas/FileType'
-    
+
     MultipartInitiateResponse:
       type: object
       required:
@@ -5640,7 +5641,7 @@ components:
           description: Presigned URLs and headers for each part
           items:
             $ref: '#/components/schemas/PartInfo'
-    
+
     PartInfo:
       type: object
       required:
@@ -5662,7 +5663,7 @@ components:
           description: Headers to include with the upload request
           example:
             Authorization: 'Bearer token'
-    
+
     MultipartCompleteRequest:
       type: object
       required:
@@ -5695,7 +5696,7 @@ components:
                 type: string
                 description: ETag returned from S3 part upload
                 example: '"abc123def456"'
-    
+
     MultipartAbortRequest:
       type: object
       required:
@@ -5710,7 +5711,7 @@ components:
           type: string
           description: File ID from initiate response
           example: 'file-def456'
-    
+
     FinetuneResponse:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3534,6 +3534,7 @@ paths:
 
   /evaluations:
     get:
+      tags: ['Evaluations']
       summary: List evaluation jobs
       description: Get a list of evaluation jobs with optional filtering
       operationId: evaluations-list


### PR DESCRIPTION
Currently the evaluations endpoints are in conflict with each other. I believe they should be grouped under the same name, /evaluations, but adding an x-stainless-resource-name may fix the issue. Let's hope this works!