### PR TITLE
ENG-86341: docs: note Kokoro voice mixing syntax on audio-speech voice field

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10015,6 +10015,9 @@ components:
             <br>
             You can view the voices supported for each model using the /v1/voices endpoint sending the model name as the query parameter.
             [View all supported voices here](https://docs.together.ai/docs/text-to-speech#supported-voices).
+            <br>
+            <br>
+            `hexgrad/Kokoro-82M` additionally supports voice mixing, where two or more voices are combined into a single blended voice by joining their names with `+` (e.g. `af_bella+af_heart`). Optional per-voice weights can be provided in parentheses (e.g. `af_bella(2)+af_heart(1)`). Other models require a single voice name.
           type: string
         response_format:
           type: string


### PR DESCRIPTION
## Summary
- `hexgrad/Kokoro-82M` supports combining voices via `voiceA+voiceB` (equal weights) or `voiceA(2)+voiceB(1)` (weighted). Other TTS models require a single voice name.
- This updates the `voice` field description on the `audio-speech` request schema so API consumers see the syntax inline, alongside the existing voice guidance.
- Companion to [inference-pop #1803](https://github.com/togethercomputer/inference-pop/pull/1803) (validator fix) and [mintlify-docs #707](https://github.com/togethercomputer/mintlify-docs/pull/707) (user-facing docs).

## Test plan
- [ ] Generated API reference renders the new description correctly
- [ ] SDK regeneration (if auto-triggered) picks up the updated schema without breaking types

🤖 Generated with [Claude Code](https://claude.com/claude-code)