### PR TITLE
Add per-token logprobs content schema to LogprobsPart

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9090,6 +9090,45 @@ components:
       additionalProperties:
         type: number
 
+    LogprobsTokenTopLogprob:
+      type: object
+      description: A candidate token and its log probability at a given position.
+      properties:
+        token:
+          type: string
+          description: The token string
+        bytes:
+          type: array
+          items:
+            type: integer
+          description: UTF-8 byte representation of the token
+          nullable: true
+        logprob:
+          type: number
+          description: The log probability of this token
+
+    LogprobsToken:
+      type: object
+      description: Log probability information for a single token in the completion.
+      properties:
+        token:
+          type: string
+          description: The token string
+        bytes:
+          type: array
+          items:
+            type: integer
+          description: UTF-8 byte representation of the token
+          nullable: true
+        logprob:
+          type: number
+          description: The log probability of this token
+        top_logprobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/LogprobsTokenTopLogprob'
+          description: List of the most likely tokens and their log probabilities at this position
+
     LogprobsPart:
       type: object
       properties:
@@ -9110,6 +9149,12 @@ components:
           description: List of token log probabilities
         top_logprobs:
           $ref: '#/components/schemas/TopLogprobs'
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/LogprobsToken'
+          description: Per-token log probability information including top alternative tokens
+          nullable: true
 
     PromptPart:
       type: array


### PR DESCRIPTION
## Summary
- Adds `LogprobsToken` and `LogprobsTokenTopLogprob` schema types to describe the per-token logprobs structure the API already returns
- Adds `content` field to `LogprobsPart` referencing the new types
- All fields optional for backwards compatibility

## Problem
The chat completions API returns logprobs in a `content` array with nested `top_logprobs` per token, but the OpenAPI spec only describes the legacy flat format (`tokens`, `token_logprobs`, `token_ids`). This causes the Stainless-generated Python SDK to silently drop `content` and per-token `top_logprobs` during deserialization. This brings back lost functionality from 1.x.x to 2.x.x. 


## Verification
Confirmed via raw curl that the API returns the `content[].top_logprobs[]` structure. The spec change matches the actual response format exactly.

Fixes https://linear.app/together-ai/issue/ENG-86462/fix-logprob-misalignment-with-open-sdk