### PR TITLE
chore: reuse open sync PR instead of opening a new one each run

### DIFF
--- a/.github/workflows/sync-openapi-spec-to-docs.yml
+++ b/.github/workflows/sync-openapi-spec-to-docs.yml
@@ -42,16 +42,22 @@ jobs:
             exit 0
           fi
 
-          BRANCH_NAME=sync-openapi-$(date +%s)
+          BRANCH_NAME=sync-openapi
 
           git checkout -b "$BRANCH_NAME"
           git add openapi.yaml
           git commit -m "Sync OpenAPI spec"
-          git push origin "$BRANCH_NAME"
+          git push --force origin "$BRANCH_NAME"
 
-          gh pr create \
-            --title "Sync OpenAPI spec" \
-            --body "This PR syncs the openapi.yaml from the togethercomputer/openapi repository." \
-            --base main \
-            --head "$BRANCH_NAME" \
-            --assignee ryanto,zainhas,Nutlope
+          EXISTING_PR=$(gh pr list --state open --head "$BRANCH_NAME" --json number --jq '.[0].number')
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Updated existing PR #$EXISTING_PR"
+          else
+            gh pr create \
+              --title "Sync OpenAPI spec" \
+              --body "This PR syncs the openapi.yaml from the togethercomputer/openapi repository." \
+              --base main \
+              --head "$BRANCH_NAME" \
+              --assignee ryanto,zainhas,Nutlope,muhsinking
+          fi


### PR DESCRIPTION
## Summary
- Switches the docs-sync workflow to a fixed `sync-openapi` branch and force-pushes each run, so consecutive `openapi.yaml` changes update the existing PR in `mintlify-docs` instead of stacking new ones.
- Only calls `gh pr create` when no open PR exists for the branch; otherwise logs that the existing PR was updated.
- Adds `muhsinking` to the assignee list for newly created sync PRs.

## Notes / tradeoffs
- Force-pushes to the `sync-openapi` branch — fine since it's bot-only, but any hand-edits to that branch would be overwritten.
- If a sync PR is *closed without merging*, the next run will open a fresh PR (we only check `--state open`). This seemed like the right default — closing signals "don't want this" — but easy to change if we'd rather reopen.
- Each sync replaces the previous diff rather than adding commits, so the PR always shows "current main → latest spec" instead of a running history of syncs.

## Test plan
- [ ] Merge, then push a no-op change to `openapi.yaml` and confirm a single PR opens in `mintlify-docs`.
- [ ] Push a second change before merging the first and confirm the existing PR gets updated (no second PR).
- [ ] Merge or close the PR, push another change, and confirm a fresh PR is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)