### PR TITLE
fix: document per-model response_encoding and sample_rate behavior

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9994,7 +9994,7 @@ components:
             - zh
         response_encoding:
           type: string
-          description: Audio encoding of response
+          description: Audio encoding of response. Only applicable when response_format is raw or pcm. Cartesia models respect this parameter and support all values. Orpheus, Kokoro, and Minimax models always return pcm_s16le regardless of this setting.
           default: pcm_f32le
           enum:
             - pcm_f32le
@@ -10004,7 +10004,7 @@ components:
         sample_rate:
           type: integer
           default: 44100
-          description: Sampling rate to use for the output audio. The default sampling rate for canopylabs/orpheus-3b-0.1-ft and hexgrad/Kokoro-82M is 24000 and for cartesia/sonic is 44100.
+          description: Sampling rate in Hz for the output audio. Cartesia and Minimax models respect this parameter. Orpheus and Kokoro models always output at 24000 Hz regardless of this setting.
         bit_rate:
           type: integer
           description: Bitrate of the MP3 audio output in bits per second. Only applicable when response_format is mp3. Higher values produce better audio quality at larger file sizes. Default is 128000. Currently supported on Cartesia models.


### PR DESCRIPTION
## Summary

Clarify in the OpenAPI spec that `response_encoding` and `sample_rate` behavior varies by model.

## Changes

**`response_encoding`**: Added note that only Cartesia models respect this parameter. Orpheus, Kokoro, and Minimax always return `pcm_s16le` regardless of this setting.

**`sample_rate`**: Added note that only Cartesia and Minimax models respect this parameter. Orpheus and Kokoro always output at 24000 Hz regardless.

Defaults unchanged (`pcm_f32le` and `44100`) since that's what inference-pop sends — the descriptions now clarify per-model behavior so users know what to expect.

## Context

Tracked in Linear: MLE-5155

🤖 Generated with [Claude Code](https://claude.com/claude-code)